### PR TITLE
Add Glacier evolution output

### DIFF
--- a/combine1d/core/cost_function.py
+++ b/combine1d/core/cost_function.py
@@ -168,7 +168,8 @@ def cost_fct(unknown_parameters, data_logger):
     else:
         spinup_control_vars = {}
 
-    # sfc_h only saved for the evaluation of idealized experiments
+    # sfc_h saved to be able to save the past glacier evolution after the
+    # minimisation and for the evaluation of idealized experiments
     sfc_h_start = flowline.surface_h.detach().clone()
 
     observations = data_logger.observations
@@ -321,19 +322,18 @@ def initialise_flowline(unknown_parameters, data_logger):
                 fl_vars_total['bed_h'][var_index] = (
                         fl_control_vars[var] / scale_fct * scale_fct.mean()
                 )
-                fl_vars_total['bed_h'][~var_index] = torch.tensor(known_parameters['bed_h'],
-                                                                  dtype=torch_type,
-                                                                  device=device,
-                                                                  requires_grad=False)
+                fl_vars_total['bed_h'][~var_index] = torch.tensor(
+                    known_parameters['bed_h'], dtype=torch_type, device=device,
+                    requires_grad=False)
             else:
                 fl_vars_total[var][var_index] = fl_control_vars[var]
-                fl_vars_total[var][~var_index] = torch.tensor(known_parameters[var],
-                                                              dtype=torch_type,
-                                                              device=device,
-                                                              requires_grad=False)
+                fl_vars_total[var][~var_index] = torch.tensor(
+                    known_parameters[var], dtype=torch_type, device=device,
+                    requires_grad=False)
 
         else:
-            # if w0_m is no control variable it is calculated to fit widths_m of flowline_init
+            # if w0_m is no control variable it is calculated to fit widths_m
+            # of flowline_init
             if var == 'w0_m':
                 var_index = (trap_index & ice_mask)
                 init_widths = torch.tensor(fl_init.widths_m,
@@ -355,7 +355,8 @@ def initialise_flowline(unknown_parameters, data_logger):
                                  fl_vars_total['bed_h'][var_index]),
                                 min=data_logger.min_w0_m)
                 fl_vars_total[var][~var_index] = torch.tensor(
-                    fl_init._w0_m[~(data_logger.ice_mask & data_logger.is_trapezoid)],
+                    fl_init._w0_m[~(data_logger.ice_mask &
+                                    data_logger.is_trapezoid)],
                     dtype=torch_type,
                     device=device,
                     requires_grad=False)
@@ -403,18 +404,19 @@ def initialise_mb_models(unknown_parameters,
             # -1 because period defined as [y0 - halfsize, y0 + halfsize + 1]
             y0 = (y_start + y_end - 1) / 2
             halfsize = (y_end - y_start - 1) / 2
-            mb_models[mb_mdl_set] = {'mb_model': ConstantMassBalanceTorch(gdir,
-                                                                          y0=y0,
-                                                                          halfsize=halfsize,
-                                                                          torch_type=torch_type,
-                                                                          device=device),
-                                     'years': mb_models_settings[mb_mdl_set]['years']}
+            mb_models[mb_mdl_set] = {'mb_model':
+                                     ConstantMassBalanceTorch(
+                                         gdir, y0=y0, halfsize=halfsize,
+                                         torch_type=torch_type, device=device),
+                                     'years':
+                                     mb_models_settings[mb_mdl_set]['years']}
         else:
             raise NotImplementedError("The MassBalance type "
-                                      f"{mb_models_settings[mb_mdl_set]['type']} is not "
-                                      "implemented!")
+                                      f"{mb_models_settings[mb_mdl_set]['type']} "
+                                      f"is not implemented!")
 
-    mb_control_var = {}  # only needed if in the future control variables are included in MB-Models
+    # only needed if in the future control variables are included in MB-Models
+    mb_control_var = {}
     return mb_models, mb_control_var
 
 

--- a/combine1d/core/data_logging.py
+++ b/combine1d/core/data_logging.py
@@ -264,6 +264,12 @@ class DataLogger(object):
             # Attention pickle only is guaranteed to work if the same xarray
             # version is used for opening as is used for writing!
             pickle.dump(ds, handle, protocol=pickle.HIGHEST_PROTOCOL)
+        # also save version of xarray
+        out = os.path.join(self.output_filepath, self.filename + '_xr_version.txt')
+        with open(out, 'w') as f:
+            f.write('The xarray version is needed to open the pickle file '
+                    'correctly \n')
+            f.write(f'xarray = {xr.__version__}')
 
         # to open it use:
         # with open('filename.pkl', 'rb') as handle:

--- a/combine1d/core/dynamics.py
+++ b/combine1d/core/dynamics.py
@@ -2,9 +2,6 @@ from collections import OrderedDict
 import copy
 
 import torch
-import numpy as np
-
-from combine1d.core.flowline import FluxBasedModel
 
 
 def run_model_and_get_temporal_model_data(flowline, dynamic_model, mb_models,
@@ -14,6 +11,7 @@ def run_model_and_get_temporal_model_data(flowline, dynamic_model, mb_models,
     Parameters
     ----------
     flowline: py:class:`oggm.Flowline`
+    dynamic_model: py:class:`oggm.FlowlineModel`
     mb_models: dict
         {'MB1': {'mb_model': lala, 'years': np.array([1950, 2010])}}
     observations: dict
@@ -137,7 +135,7 @@ def run_model_and_get_model_values(flowline, dynamic_model, mb_models,
                     actual_model_data[obs_yr][var] = dyn_model.fls[0].widths_m
                 elif var == 'us:myr-1':
                     actual_model_data[obs_yr][var] = dyn_model.u_stag * \
-                        dyn_model.surf_vel_fac * dyn_model.sec_in_year
+                        dyn_model._surf_vel_fac * dyn_model.sec_in_year
                 else:
                     raise NotImplementedError(f'{var}')
 

--- a/combine1d/core/flowline.py
+++ b/combine1d/core/flowline.py
@@ -932,6 +932,33 @@ class FlowlineModelTorch(FlowlineModelOGGM):
                     raise FloatingPointError('NaN in numerical solution, '
                                              'at year: {}'.format(self.yr))
 
+    def run_until_and_store(self, y1,
+                            diag_path=None,
+                            fl_diag_path=False,
+                            geom_path=False,
+                            store_monthly_step=None,
+                            stop_criterion=None,
+                            fixed_geometry_spinup_yr=None,
+                            dynamic_spinup_min_ice_thick=None,
+                            make_compatible=False
+                            ):
+        ds = FlowlineModelOGGM.run_until_and_store(
+            self, y1=y1, diag_path=None, fl_diag_path=fl_diag_path,
+            geom_path=geom_path, store_monthly_step=store_monthly_step,
+            stop_criterion=stop_criterion,
+            fixed_geometry_spinup_yr=fixed_geometry_spinup_yr,
+            dynamic_spinup_min_ice_thick=dynamic_spinup_min_ice_thick,
+            make_compatible=make_compatible)
+
+        # convert some values to numpy
+        ds.attrs['glen_a'] = ds.attrs['glen_a'].detach().to('cpu').numpy()
+        ds.attrs['fs'] = ds.attrs['fs'].detach().to('cpu').numpy()
+
+        if diag_path is not None:
+            ds.to_netcdf(diag_path)
+
+        return ds
+
 
 class RectangularBedDiffusiveFlowlineModel(FlowlineModelTorch):
     """A rectangular bed diffusive model, not used in the Thesis of COMBINE1D.

--- a/combine1d/core/massbalance.py
+++ b/combine1d/core/massbalance.py
@@ -206,9 +206,12 @@ class ConstantMassBalanceTorch(ConstantMassBalance):
             the file suffix of the input climate file
         """
 
-        super(ConstantMassBalanceTorch, self).__init__(gdir, mu_star=mu_star, bias=bias,
-                                                       y0=y0, halfsize=halfsize, filename=filename,
-                                                       input_filesuffix=input_filesuffix, **kwargs)
+        super(ConstantMassBalanceTorch, self).__init__(gdir, mu_star=mu_star,
+                                                       bias=bias, y0=y0,
+                                                       halfsize=halfsize,
+                                                       filename=filename,
+                                                       input_filesuffix=input_filesuffix,
+                                                       **kwargs)
 
         self.torch_type = torch_type
         self.device = device

--- a/combine1d/sandbox/create_glaciers_with_measurements.py
+++ b/combine1d/sandbox/create_glaciers_with_measurements.py
@@ -372,6 +372,19 @@ def evolve_glacier_and_create_measurements(gdir, used_mb_models, yr_start_run,
                       filesuffix='_combine_true_end')
     dh_volume[1] = model.volume_m3
     dh_area[1] = model.area_m2
+    # combine model diagnostics to one file for the whole period
+    tasks.merge_consecutive_run_outputs(
+        gdir,
+        input_filesuffix_1='_combine_spinup',
+        input_filesuffix_2='_combine_true_init',
+        output_filesuffix='_combine_total_run',
+        delete_input=False)
+    tasks.merge_consecutive_run_outputs(
+        gdir,
+        input_filesuffix_1='_combine_total_run',
+        input_filesuffix_2='_combine_end',
+        output_filesuffix='_combine_total_run',
+        delete_input=False)
 
     # calculate dh
     dh_m = (dh_volume[1] - dh_volume[0]) / \

--- a/combine1d/sandbox/create_glaciers_with_measurements.py
+++ b/combine1d/sandbox/create_glaciers_with_measurements.py
@@ -6,7 +6,7 @@ from oggm.cfg import SEC_IN_YEAR
 from scipy.optimize import brentq
 
 from oggm import cfg, workflow, tasks, entity_task, utils
-from oggm.core.flowline import MixedBedFlowline, FluxBasedModel
+from oggm.core.flowline import MixedBedFlowline, SemiImplicitModel
 from oggm.core.massbalance import ConstantMassBalance, MultipleFlowlineMassBalance, \
     PastMassBalance, RandomMassBalance
 from oggm.shop import bedtopo
@@ -40,8 +40,6 @@ def create_idealized_experiments(all_glaciers,
 
     cfg.PARAMS['min_ice_thick_for_length'] = 0.01
     cfg.PARAMS['glacier_length_method'] = 'consecutive'
-    # use very small cfl_number to avoid instabilities in experiment creation
-    cfg.PARAMS['cfl_number'] = 0.001
 
     # check if glaciers are already defined
     for glacier in all_glaciers:
@@ -235,15 +233,15 @@ def create_spinup_glacier(gdir, rgi_id_to_name, yr_start_run, yr_end_run,
     def get_spinup_glacier(t_bias):
         # first run random climate with t_bias
         mb_random.temp_bias = t_bias
-        model = FluxBasedModel(copy.deepcopy(fls_spinup),
-                               mb_random,
-                               y0=0)
+        model = SemiImplicitModel(copy.deepcopy(fls_spinup),
+                                  mb_random,
+                                  y0=0)
         model.run_until(years_to_run_random)
 
         # from their use a climate run
-        model = FluxBasedModel(copy.deepcopy(model.fls),
-                               mb_past,
-                               y0=1930)
+        model = SemiImplicitModel(copy.deepcopy(model.fls),
+                                  mb_past,
+                                  y0=1930)
         model.run_until(yr_spinup)
 
         return model
@@ -253,14 +251,14 @@ def create_spinup_glacier(gdir, rgi_id_to_name, yr_start_run, yr_end_run,
         model_spinup = get_spinup_glacier(t_bias)
 
         # Now conduct the actual model run to the rgi date
-        model_historical_1 = FluxBasedModel(model_spinup.fls,
-                                            mb_const_1,
-                                            y0=yr_spinup)
+        model_historical_1 = SemiImplicitModel(model_spinup.fls,
+                                               mb_const_1,
+                                               y0=yr_spinup)
         model_historical_1.run_until(yr_start_run)
 
-        model_historical_2 = FluxBasedModel(model_historical_1.fls,
-                                            mb_const_2,
-                                            y0=yr_start_run)
+        model_historical_2 = SemiImplicitModel(model_historical_1.fls,
+                                               mb_const_2,
+                                               y0=yr_start_run)
         model_historical_2.run_until(yr_rgi)
 
         cost = (model_historical_2.length_m - length_m_ref) / length_m_ref * 100
@@ -333,12 +331,18 @@ def evolve_glacier_and_create_measurements(gdir, used_mb_models, yr_start_run,
         raise NotImplementedError(f'{used_mb_models}')
 
     # do spinup period before first measurement
-    model = FluxBasedModel(copy.deepcopy(fls_spinup),
-                           mb_spinup,
-                           y0=yr_spinup)
-    model.run_until_and_store(yr_start_run,
-                              diag_path=gdir.get_filepath('model_diagnostics',
-                                                          filesuffix='_combine_spinup'))
+    model = SemiImplicitModel(copy.deepcopy(fls_spinup),
+                              mb_spinup,
+                              y0=yr_spinup)
+    model.run_until_and_store(
+        yr_start_run,
+        diag_path=gdir.get_filepath('model_diagnostics',
+                                    filesuffix='_combine_spinup',
+                                    delete=True),
+        fl_diag_path=gdir.get_filepath('fl_diagnostics',
+                                       filesuffix='_combine_spinup',
+                                       delete=True)
+    )
 
     # get measurements for dhdt
     dh_volume = [None, None]
@@ -347,13 +351,18 @@ def evolve_glacier_and_create_measurements(gdir, used_mb_models, yr_start_run,
     dh_area[0] = model.area_m2
 
     # switch to mb_run and run to rgi_date and save measurements and flowline
-    model = FluxBasedModel(copy.deepcopy(model.fls),
-                           mb_run,
-                           y0=yr_start_run)
-    model.run_until_and_store(yr_rgi,
-                              diag_path=gdir.get_filepath('model_diagnostics',
-                                                          filesuffix='_combine_true_init')
-                              )
+    model = SemiImplicitModel(copy.deepcopy(model.fls),
+                              mb_run,
+                              y0=yr_start_run)
+    model.run_until_and_store(
+        yr_rgi,
+        diag_path=gdir.get_filepath('model_diagnostics',
+                                    filesuffix='_combine_true_init',
+                                    delete=True),
+        fl_diag_path=gdir.get_filepath('fl_diagnostics',
+                                       filesuffix='_combine_true_init',
+                                       delete=True)
+    )
     gdir.write_pickle(model.fls, 'model_flowlines',
                       filesuffix='_combine_true_init')
     rgi_date_area_km2 = model.area_km2
@@ -361,12 +370,17 @@ def evolve_glacier_and_create_measurements(gdir, used_mb_models, yr_start_run,
     rgi_date_us_myr = model.u_stag[0] * model._surf_vel_fac * SEC_IN_YEAR
 
     # now run to the end for dhdt
-    model.run_until_and_store(yr_end_run,
-                              diag_path=gdir.get_filepath('model_diagnostics',
-                                                          filesuffix='_combine_end'),
-                              geom_path=gdir.get_filepath('model_geometry',
-                                                          filesuffix='_combine_end',
-                                                          delete=True)
+    model.run_until_and_store(
+        yr_end_run,
+        diag_path=gdir.get_filepath('model_diagnostics',
+                                    filesuffix='_combine_end',
+                                    delete=True),
+        geom_path=gdir.get_filepath('model_geometry',
+                                    filesuffix='_combine_end',
+                                    delete=True),
+        fl_diag_path=gdir.get_filepath('fl_diagnostics',
+                                       filesuffix='_combine_end',
+                                       delete=True)
                               )
     gdir.write_pickle(model.fls, 'model_flowlines',
                       filesuffix='_combine_true_end')

--- a/combine1d/sandbox/glaciers_for_idealized_experiments.py
+++ b/combine1d/sandbox/glaciers_for_idealized_experiments.py
@@ -11,7 +11,7 @@ experiment_glaciers = {
     'Hintereisferner': {
         'rgi_id': 'RGI60-11.00897',
         't_bias_spinup_limits': (-1, 0),  # not used during creation
-        't_bias_spinup': 1.2,
+        't_bias_spinup': 1.4,
     },
     'Aletsch': {
         'rgi_id': 'RGI60-11.01450',

--- a/combine1d/tests/test_inversion.py
+++ b/combine1d/tests/test_inversion.py
@@ -1,3 +1,5 @@
+import os
+import pickle
 import numpy as np
 import xarray as xr
 import pytest
@@ -120,6 +122,22 @@ class TestInversion:
         assert data_logger.parameter_indices is not None
         assert data_logger.unknown_parameters is not None
         assert data_logger.observations_mdl is not None
+
+        # test if data during minimisation is saved to disk
+        # look for xarray version and check
+        fp = os.path.join(hef_gdir.dir,
+                          'Hintereisferner_COMBINE_inversion_results_'
+                          'xr_version.txt')
+        with open(fp, 'r') as f:
+            saved_version = f.readlines()[1].split(' ')[2]
+        assert xr.__version__ == saved_version
+
+        fp = os.path.join(hef_gdir.dir,
+                          'Hintereisferner_COMBINE_inversion_results.pkl')
+        with open(fp, 'rb') as handle:
+            ds_saved = pickle.load(handle)
+        assert type(ds_saved) == xr.core.dataset.Dataset
+        assert ds_saved.costs[0] > ds_saved.costs[-1]
 
         # test past evolution
         assert hef_gdir.has_file(

--- a/combine1d/tests/test_sandbox.py
+++ b/combine1d/tests/test_sandbox.py
@@ -1,0 +1,120 @@
+import pytest
+import matplotlib.pyplot as plt
+from combine1d.sandbox.create_glaciers_with_measurements import create_idealized_experiments
+from oggm import cfg, utils, workflow, tasks, graphics
+import xarray as xr
+import numpy as np
+
+do_plot = False
+
+
+class TestSandbox:
+    def test_create_idealized_experiments(self, test_dir):
+        cfg.initialize(logging_level='WARNING')
+        cfg.PATHS['working_dir'] = test_dir
+        cfg.PARAMS['use_multiprocessing'] = False
+
+        # Size of the map around the glacier.
+        prepro_border = 160
+        # Degree of processing level.
+        from_prepro_level = 2
+        # URL of the preprocessed gdirs
+        # we use elevation bands flowlines here
+        base_url = 'https://cluster.klima.uni-bremen.de/~oggm/gdirs/oggm_v1.6/' \
+                   'L1-L2_files/elev_bands/'
+
+        glacier_names = ['Baltoro',
+                         'Hintereisferner',
+                         'Aletsch',
+                         'Artesonraju',
+                         'Shallap'
+                         ]
+
+        cfg.PARAMS['use_multiprocessing'] = False
+        gdirs = create_idealized_experiments(glacier_names,
+                                             prepro_border=prepro_border,
+                                             from_prepro_level=from_prepro_level,
+                                             base_url=base_url, )
+
+        # test that resulting dataset contain the complete experiment period
+        for gdir in gdirs:
+            fp = gdir.get_filepath('model_diagnostics',
+                                   filesuffix='_combine_total_run')
+            with xr.open_dataset(fp) as ds_diag:
+                ds_diag = ds_diag.load()
+
+            assert ds_diag.time[0] == 1980
+            assert ds_diag.time[-1] == 2019
+            assert np.all(np.isfinite(ds_diag.volume_m3))
+            assert np.all(np.isfinite(ds_diag.area_m2))
+            assert np.all(np.isfinite(ds_diag.length_m))
+
+        if do_plot:
+            for gdir in gdirs:
+                fl_oggm = gdir.read_pickle('model_flowlines')[0]
+                fl_consensus = gdir.read_pickle('model_flowlines', filesuffix='_consensus')[0]
+                fl_spinup = gdir.read_pickle('model_flowlines', filesuffix='_spinup')[0]
+                fl_combine_init = \
+                gdir.read_pickle('model_flowlines', filesuffix='_combine_true_init')[0]
+                fl_combine_end = \
+                gdir.read_pickle('model_flowlines', filesuffix='_combine_true_end')[0]
+                fl_combine_first_guess = \
+                gdir.read_pickle('model_flowlines', filesuffix='_combine_first_guess')[0]
+
+                def get_fl_diagnostics(filesuffix):
+                    f = gdir.get_filepath('fl_diagnostics', filesuffix=filesuffix)
+                    with xr.open_dataset(f, group=f'fl_0') as ds:
+                        ds = ds.load()
+                    return ds
+
+                fl_diag_init = get_fl_diagnostics('_combine_spinup')
+                fl_diag_start = get_fl_diagnostics('_combine_true_init')
+                fl_diag_end = get_fl_diagnostics('_combine_end')
+
+                fig = plt.figure(figsize=(15, 10))
+                (ax, ax2, ax3, ax4, ax5, ax6) = fig.subplots(6, 1)
+                # ax.plot(fl_oggm.dis_on_line, fl_oggm.bed_h, label='OGGM Flowline')
+                ax.plot(fl_spinup.dis_on_line, fl_spinup.bed_h, label='Spinup Flowline')
+                ax.plot(fl_oggm.dis_on_line, fl_oggm.surface_h, label='OGGM surface_h')
+                ax.plot(fl_spinup.dis_on_line, fl_spinup.surface_h, label='Spinup surface_h')
+                # ax.plot(fl_consensus.dis_on_line, fl_consensus.surface_h, label='Consensus surface_h')
+                ax.plot(fl_combine_init.dis_on_line, fl_combine_init.surface_h,
+                        label='Init surface_h')
+                ax.plot(fl_combine_end.dis_on_line, fl_combine_end.surface_h,
+                        label='END surface_h')
+                ax.legend();
+
+                ax2.axhline(0, color='black')
+                ax2.plot(fl_spinup.surface_h - fl_combine_init.surface_h,
+                         label='positive means retreating (spinup to rgi _date)')
+                ax2.plot(fl_combine_init.surface_h - fl_combine_end.surface_h,
+                         label='rgi_date to end')
+                ax2.set_title('delta surface_h')
+                ax2.legend()
+
+                ax3.axhline(0, color='black')
+                ax3.plot(fl_spinup.bed_h - fl_combine_first_guess.bed_h,
+                         label='positive means overdeepening')
+                ax3.set_title('delta bed_h')
+                ax3.legend()
+
+                ax4.plot(fl_combine_first_guess.is_trapezoid, label='trapez')
+                ax4.plot(fl_combine_first_guess.is_rectangular, label='rect')
+                ax4.legend()
+
+                ax5.plot(fl_oggm.thick > 0, label='OGGM thick > 0')
+                ax5.plot(fl_combine_init.thick > 0, label='COMBINE init thick > 0')
+                ax5.legend()
+
+                ax6.plot(fl_diag_init.ice_velocity_myr[-1],
+                         label=f'year {fl_diag_init.time[-1].values}')
+                ax6.plot(fl_diag_start.ice_velocity_myr[-1],
+                         label=f'year {fl_diag_start.time[-1].values} (rgi date)')
+                ax6.plot(fl_diag_end.ice_velocity_myr[-1],
+                         label=f'year {fl_diag_end.time[-1].values}')
+                ax6.set_title('velocity')
+                ax6.legend()
+
+                fig.suptitle(gdir.name, fontsize=16)
+                fig.tight_layout(pad=1.0)
+                plt.show()


### PR DESCRIPTION
With this PR, the past model evolution of the final minimisation run is saved in one file (not only today's glacier state, related to https://github.com/OGGM/COMBINE/issues/12). For this, I cleaned up the code for inheriting `run_until_and_store` from the oggm base class `FlowlineModel`.

But still, not included as a single file are the past flowline diagnostics and model geometry. For this, I have to adapt the oggm function `merge_consecutive_run_outputs`.

Further, I adapted the idealized Experiments to use the SemiImplicitScheme of oggm for the glacier creation. And I added some tests for the created idealized Experiments. 