### PR TITLE
Add MassBalanceModelWrapper

### DIFF
--- a/combine1d/core/cost_function.py
+++ b/combine1d/core/cost_function.py
@@ -3,11 +3,13 @@ import logging
 import numpy as np
 import torch
 import time
+from functools import partial
 
 from combine1d.core.dynamics import run_model_and_get_temporal_model_data
 from combine1d.core.massbalance import ConstantMassBalanceTorch
 from combine1d.core.flowline import MixedBedFlowline, FluxBasedModel
 from oggm.core.flowline import MixedBedFlowline as OggmFlowline
+from oggm import cfg
 
 log = logging.getLogger(__name__)
 
@@ -142,6 +144,13 @@ def cost_fct(unknown_parameters, data_logger):
                                                     data_logger)
 
     dynamic_model = data_logger.dynamic_model
+
+    if cfg.PARAMS['use_inversion_params_for_run']:
+        diag = data_logger.gdir.get_diagnostics()
+        fs = diag.get('inversion_fs', cfg.PARAMS['fs'])
+        glen_a = diag.get('inversion_glen_a', cfg.PARAMS['glen_a'])
+        dynamic_model = partial(dynamic_model,
+                                fs=fs, glen_a=glen_a)
 
     mb_models, mb_control_vars = initialise_mb_models(unknown_parameters,
                                                       data_logger)

--- a/combine1d/core/cost_function.py
+++ b/combine1d/core/cost_function.py
@@ -401,6 +401,13 @@ def initialise_mb_models(unknown_parameters,
         if mb_models_settings[mb_mdl_set]['type'] == 'constant':
             y_start = mb_models_settings[mb_mdl_set]['years'][0]
             y_end = mb_models_settings[mb_mdl_set]['years'][1]
+
+            # for a constant mass balance we currently only can define an end
+            # year of 2019, the model can still run until 2020 as it do not
+            # need the mass balance from 2020 for this
+            if y_end == 2020:
+                y_end = 2019
+
             # -1 because period defined as [y0 - halfsize, y0 + halfsize + 1]
             y0 = (y_start + y_end - 1) / 2
             halfsize = (y_end - y_start - 1) / 2

--- a/combine1d/core/data_logging.py
+++ b/combine1d/core/data_logging.py
@@ -141,9 +141,9 @@ class DataLogger(object):
         raise NotImplementedError('Not added yet!')
 
     def save_data_in_datalogger(self, var, data):
-        if type(data) == torch.Tensor:
+        if isinstance(data, torch.Tensor):
             data = data.detach().to('cpu').numpy().astype(np.float64)
-        elif type(data) != np.ndarray:
+        elif not isinstance(data, np.ndarray):
             data = np.array(data)
 
         current_var = getattr(self, var)

--- a/combine1d/core/dynamics.py
+++ b/combine1d/core/dynamics.py
@@ -129,7 +129,6 @@ def run_model_and_get_model_values(flowline, dynamic_model, mb_models,
         dyn_model = dynamic_model(flowline,
                                   mb_model=mb_models[mb_key]['mb_model'],
                                   y0=mb_models[mb_key]['years'][0],
-                                  fs=0.,
                                   mb_elev_feedback='annual')
 
         # years with observations using the same mass balance model

--- a/combine1d/core/flowline.py
+++ b/combine1d/core/flowline.py
@@ -455,7 +455,7 @@ class MixedBedFlowline(Flowline):
             self._w0_m = w0_m
 
         assert len(bed_shape) == self.nx
-        if type(bed_shape) == torch.Tensor:
+        if isinstance(bed_shape, torch.Tensor):
             warnings.warn('Gradient calculation not possible for bed_shape!')
         self.bed_shape = torch.tensor(bed_shape,
                                       dtype=self.torch_type,
@@ -775,7 +775,7 @@ class FlowlineModelTorch(FlowlineModelOGGM):
             # among use cases (monthly or yearly output) and also to prevent
             # "too large" steps in the adaptive scheme.
             ts = utils.monthly_timeseries(self.yr.detach().to('cpu').numpy()
-                                          if type(self.yr) == torch.Tensor
+                                          if isinstance(self.yr, torch.Tensor)
                                           else self.yr, y1)
 
             # Add the last date to be sure we end on it
@@ -1378,7 +1378,7 @@ class SemiImplicitModel(FlowlineModelTorch):
                         'bin_id {} and max_D/w {:.3f} m2 yr-1. '
                         'To avoid memory overflow!'
                         ''.format(cfl_dt, self.min_dt, self.yr, 0,
-                                  np.argmax(np.abs(d_stag)),
+                                  np.argmax(np.abs(d_stag.detach())),
                                   divisor * cfg.SEC_IN_YEAR))
 
         # calculate diagonals of Amat

--- a/combine1d/core/inversion.py
+++ b/combine1d/core/inversion.py
@@ -43,13 +43,16 @@ def get_default_inversion_settings(get_doc=False):
     _key = "mb_models_settings"
     _doc = "Defines the used MassBalanceModels in a dictionary. The key is the " \
            "name, the value is again a dictionary with keys 'type' (options: " \
-           "'constant') and 'years' (the interval the model is valid in an " \
-           "numpy array). Caution first MassBalanceModel must start at least " \
+           "'constant' or 'TIModel') and 'years' (the interval the model is valid in an " \
+           "numpy array, if empty MB is valid for whole period). This interval " \
+           "defines also the period of the model run. Caution first " \
+           "MassBalanceModel must start at least " \
            "one year before first given observation year!" \
-           "Default: {'MB1': {'type': 'constant', 'years': np.array([1980, 2000])}," \
-           "'MB2': {'type': 'constant', 'years': np.array([2000, 2020])}}"
-    _default = {'MB1': {'type': 'constant', 'years': np.array([1980, 2000])},
-                'MB2': {'type': 'constant', 'years': np.array([2000, 2020])}}
+           "Default: {'MB': {'type': 'TIModel'," \
+           "                 'years': np.array([1980, 2020])}}"
+    _default = {'MB': {'type': 'TIModel',
+                       'years': np.array([1980, 2020])}}
+
     add_setting()
 
     _key = "dynamic_model"
@@ -191,12 +194,17 @@ def get_default_inversion_settings(get_doc=False):
            "height shift of the whole mb profile for an adaptive spinup " \
            "(e.g. {'height_shift': {'mb_model': " \
            "{'type': 'constant', 'years': np.array([1980, 2000]), " \
-           "'fg_height_shift': 100}}}). " \
-           "Default: {'height_shift': {'mb_model': {'type': 'constant'," \
-           "'years': np.array([1980, 2000]), 'fg_height_shift': -100}}}"
+           "'fg_height_shift': -100," \
+           "'spinup_length_yrs': 30}}}). " \
+           "Default: {'height_shift':" \
+           "    {'mb_model': {'type': 'constant'," \
+           "                  'years': np.array([1980, 2000]), " \
+           "                  'fg_height_shift': -100}," \
+           "     'spinup_length_yrs': 20}}"
     _default = {'height_shift': {'mb_model': {'type': 'constant',
                                               'years': np.array([1980, 2000]),
-                                              'fg_height_shift': -100}}}
+                                              'fg_height_shift': -100},
+                                 'spinup_length_yrs': 20}}
     add_setting()
 
     _key = "minimize_options"

--- a/combine1d/core/inversion.py
+++ b/combine1d/core/inversion.py
@@ -47,9 +47,9 @@ def get_default_inversion_settings(get_doc=False):
            "numpy array). Caution first MassBalanceModel must start at least " \
            "one year before first given observation year!" \
            "Default: {'MB1': {'type': 'constant', 'years': np.array([1980, 2000])}," \
-           "'MB2': {'type': 'constant', 'years': np.array([2000, 2019])}}"
+           "'MB2': {'type': 'constant', 'years': np.array([2000, 2020])}}"
     _default = {'MB1': {'type': 'constant', 'years': np.array([1980, 2000])},
-                'MB2': {'type': 'constant', 'years': np.array([2000, 2019])}}
+                'MB2': {'type': 'constant', 'years': np.array([2000, 2020])}}
     add_setting()
 
     _key = "dynamic_model"

--- a/combine1d/core/massbalance.py
+++ b/combine1d/core/massbalance.py
@@ -15,6 +15,7 @@ from combine1d.core.torch_interp1d import Interp1d
 # other stuff
 from functools import partial
 import numpy as np
+from itertools import tee
 
 
 class MassBalanceModel(object, metaclass=SuperclassMeta):
@@ -292,3 +293,79 @@ class ConstantMassBalanceTorch(ConstantMassBalance):
         yr, m = floatyear_to_date(year)
         return torch.squeeze(self._get_monthly_mb[m - 1](heights -
                                                          self.height_shift))
+
+
+def pairwise(iterable):
+    """ In Python 3.10 this is available in itertools.pairwise"""
+    # pairwise('ABCDEFG') --> AB BC CD DE EF FG
+    a, b = tee(iterable)
+    next(b, None)
+    return zip(a, b)
+
+
+class StackedMassBalance(MassBalanceModel):
+    """Define different MassBalanceModels for different time periods.
+    """
+
+    def __init__(self, gdir, mb_model_settings, filename='climate_historical',
+                 input_filesuffix=''):
+
+        super(StackedMassBalance, self).__init__()
+
+        self.hemisphere = gdir.hemisphere
+
+        # set periods of different mb_models
+        all_periods = []
+        for key_mb in mb_model_settings:
+            all_periods.append(mb_model_settings[key_mb]['years'])
+        self._periods = np.sort(np.unique(np.concatenate(all_periods)))
+
+        # set mb_model for all specific sorted periods
+        mb_models = {}
+        for p_nr, (p_start, p_end) in enumerate(pairwise(self._periods)):
+            # check if their is a mb_model defined for the current period
+            found_mb_model = False
+            for key_mb in mb_model_settings:
+                if np.all([p_start, p_end] ==
+                          mb_model_settings[key_mb]['years']):
+                    if mb_model_settings[key_mb]['type'] == 'constant':
+                        halfsize_run = (p_end - p_start) / 2
+                        mb_models[p_nr] = ConstantMassBalance(
+                            gdir, y0=p_start + halfsize_run,
+                            halfsize=halfsize_run, filename=filename,
+                            input_filesuffix=input_filesuffix)
+                        found_mb_model = True
+                        break
+                    else:
+                        raise NotImplementedError('')
+
+            if not found_mb_model:
+                raise ValueError(f'No mb model defined for period {p_start} '
+                                 f'to {p_end}!')
+
+        self._mb_models = mb_models
+
+    def get_period_nr(self, year):
+        current_period = np.searchsorted(self._periods, year, side='right')
+
+        # the given year is smaller than minimum defined in periods
+        if current_period == 0:
+            raise ValueError(f'No mb model defined for year {year}')
+
+        if current_period >= len(self._periods):
+            if year == self._periods[-1]:
+                # ok at the upper limit we use again the last mb_model
+                current_period -= 1
+            else:
+                # the given year is larger than the maximum defined in periods
+                raise ValueError(f'No mb model defined for year {year}')
+
+        return current_period - 1  # because mb_model index starts with 0
+
+    def get_monthly_mb(self, heights, year=None, fl_id=None, fls=None):
+        return self._mb_models[self.get_period_nr(year)].get_monthly_mb(
+            heights=heights, year=year, fl_id=fl_id, fls=fls)
+
+    def get_annual_mb(self, heights, year=None, fl_id=None, fls=None):
+        return self._mb_models[self.get_period_nr(year)].get_annual_mb(
+            heights=heights, year=year, fl_id=fl_id, fls=fls)

--- a/combine1d/sandbox/calculate_statistics.py
+++ b/combine1d/sandbox/calculate_statistics.py
@@ -7,24 +7,20 @@ from oggm import utils, cfg
 
 # define which statistic we want to compute for different types of data
 def add_1d_stats(x, y):
+    diff = x - y
     rms_deviation = utils.rmsd(x, y)
     mean_absolute_deviation = utils.mad(x, y)
     max_absolute_deviation = np.max(np.abs(x - y))
 
     return {'rmsd': float(rms_deviation),
             'mean_ad': float(mean_absolute_deviation),
-            'max_ad': float(max_absolute_deviation)}
+            'max_ad': float(max_absolute_deviation),
+            'diff': diff}
 
 
 def add_0d_stats(x, y):
     return {'diff': float(x - y),
             'abs_diff': float(np.abs(x - y))}
-
-
-def add_2d_stats(x, y):
-    return_dict = add_1d_stats(x, y)
-    return_dict['diff'] = x - y
-    return return_dict
 
 
 def calculate_result_statistics(gdir, data_logger):
@@ -127,19 +123,19 @@ def calculate_result_statistics(gdir, data_logger):
     today_state_stats = {}
     for var in ['thick', 'area_m2', 'volume_m3']:
         if var in ['thick']:
-            today_state_stats[var] = add_2d_stats(
+            today_state_stats[var] = add_1d_stats(
                 getattr(fls_end_mdl, var),
                 getattr(fls_end_true, var))
         elif var == 'area_m2':
             def get_area(fl):
                 return np.where(fl.thick > 0, fl.widths_m, 0) * fl.dx_meter
-            today_state_stats[var] = add_2d_stats(
+            today_state_stats[var] = add_1d_stats(
                 get_area(fls_end_mdl),
                 get_area(fls_end_true))
         elif var == 'volume_m3':
             def get_volume(fl):
                 return fl.section * fl.dx_meter
-            today_state_stats[var] = add_2d_stats(
+            today_state_stats[var] = add_1d_stats(
                 get_volume(fls_end_mdl),
                 get_volume(fls_end_true))
         else:
@@ -334,21 +330,21 @@ def calculate_default_oggm_statistics(gdir):
         today_state_stats = {}
         for var in ['thick', 'area_m2', 'volume_m3']:
             if var in ['thick']:
-                today_state_stats[var] = add_2d_stats(
+                today_state_stats[var] = add_1d_stats(
                     getattr(fls_end_mdl, 'thickness_m').values,
                     getattr(fls_end_true, var))
             elif var == 'area_m2':
                 def get_area(fl):
                     return np.where(fl.thick > 0, fl.widths_m, 0) * fl.dx_meter
 
-                today_state_stats[var] = add_2d_stats(
+                today_state_stats[var] = add_1d_stats(
                     getattr(fls_end_mdl, 'area_m2').values,
                     get_area(fls_end_true))
             elif var == 'volume_m3':
                 def get_volume(fl):
                     return fl.section * fl.dx_meter
 
-                today_state_stats[var] = add_2d_stats(
+                today_state_stats[var] = add_1d_stats(
                     getattr(fls_end_mdl, 'volume_m3').values,
                     get_volume(fls_end_true))
             else:

--- a/combine1d/sandbox/graphics.py
+++ b/combine1d/sandbox/graphics.py
@@ -162,8 +162,8 @@ def plot_heading_text(gdir, fig, ax, parameters_text_height=0.5, linespacing=1):
         "\n"
         fr"$d_f$ = {gdir.read_json('mb_calib')['melt_f']:.1f} "
         r"kg m$^{-2}$ K$^{-1}$ day$^{-1}$, "
-        f"prcp_factor = {gdir.read_json('mb_calib')['prcp_fac']:.1f}, "
-        f"temp_bias = {gdir.read_json('mb_calib')['temp_bias']:.1f} °C",
+        fr"$p_f$ = {gdir.read_json('mb_calib')['prcp_fac']:.1f}, "
+        fr"$t_b$ = {gdir.read_json('mb_calib')['temp_bias']:.1f} °C",
         horizontalalignment='center',
         verticalalignment='top',
         transform=ax.transAxes,

--- a/combine1d/tests/conftest.py
+++ b/combine1d/tests/conftest.py
@@ -87,7 +87,8 @@ def control_vars(request):
                          },
                         {'height_shift': {'mb_model': {'type': 'constant',
                                                        'years': np.array([1980, 2000]),
-                                                       'fg_height_shift': -100}
+                                                       'fg_height_shift': -100},
+                                          'spinup_length_yrs': 20
                                           }
                          }
                         ],

--- a/combine1d/tests/test_cost_function.py
+++ b/combine1d/tests/test_cost_function.py
@@ -175,7 +175,7 @@ class TestCostFct:
         for obs_var in observations.keys():
             for year in observations[obs_var].keys():
                 assert dobs[obs_var][year] != []
-                assert type(dobs[obs_var][year]) == torch.Tensor
+                assert isinstance(dobs[obs_var][year], torch.Tensor)
                 if obs_var in ['fl_total_area:m2', 'fl_total_area:km2',
                                'area:m2', 'area:km2', 'dmdtda:kg m-2 yr-1',
                                'dmdtda:kg yr-1', 'us:myr-1']:
@@ -223,7 +223,7 @@ class TestCostFct:
         for obs_var in observations.keys():
             for year in observations[obs_var].keys():
                 assert len(reg_parameters[obs_var][year]) == 1
-                assert type(reg_parameters[obs_var][year]) == torch.Tensor
+                assert isinstance(reg_parameters[obs_var][year], torch.Tensor)
 
     def test_get_cost_terms(self, data_logger, unknown_parameters,
                             observations):
@@ -238,7 +238,7 @@ class TestCostFct:
         assert len(c_terms) == 14
         for c_term in c_terms:
             assert c_term != []
-            assert type(c_term) == torch.Tensor
+            assert isinstance(c_term, torch.Tensor)
 
     def test_get_gradients(self, data_logger, unknown_parameters,
                            observations):

--- a/combine1d/tests/test_inversion.py
+++ b/combine1d/tests/test_inversion.py
@@ -157,7 +157,7 @@ class TestInversion:
 
         # include some test that all the years are there
         assert ds.time[0] == 1980
-        assert ds.time[-1] == 2019
+        assert ds.time[-1] == 2020
         assert np.all(np.isfinite(ds.volume_m3))
         assert np.all(np.isfinite(ds.area_m2))
         assert np.all(np.isfinite(ds.length_m))

--- a/combine1d/tests/test_inversion.py
+++ b/combine1d/tests/test_inversion.py
@@ -75,7 +75,8 @@ class TestInversion:
                                                  {'type': 'constant',
                                                   'years': np.array(
                                                       [1980, 2000]),
-                                                  'fg_height_shift': -100}
+                                                  'fg_height_shift': -100},
+                                             'spinup_length_yrs': 20
                                              }
                             }
                            ],

--- a/combine1d/tests/test_sandbox.py
+++ b/combine1d/tests/test_sandbox.py
@@ -122,7 +122,7 @@ class TestSandbox:
                 pure_key = stat_key.removesuffix('_' + stat_suffixes)
                 if pure_key in ['observations_stats', 'controls_stats',
                                 'past_evol_stats', 'today_state_stats',
-                                'future_evol_stats']:
+                                'future_evol_stats', 'past_state_stats']:
                     use_year = False
                     if pure_key in ['observations_stats']:
                         use_year = True
@@ -302,6 +302,31 @@ class TestSandbox:
                     if test_default:
                         assert metric in ds_default_stats[ds_key_oggm][control_key].keys()
                         assert isinstance(ds_default_stats[ds_key_oggm][control_key][metric],
+                                          float)
+
+            # test the past glacier state statistics
+            ds_key = 'past_state_stats'
+            ds_key_oggm = ds_key + oggm_run_suffix
+            assert ds_key in ds.attrs.keys()
+            assert ds_key_oggm in ds_default_stats.keys()
+            for var in ['thick', 'area_m2', 'volume_m3']:
+                test_metrics = ['rmsd', 'mean_ad', 'max_ad', 'diff']
+                for metric in test_metrics:
+                    if metric == 'diff':
+                        if var != 'thick':
+                            assert metric in ds.attrs[ds_key][var].keys()
+                            assert metric in ds_default_stats[ds_key_oggm][var].keys()
+                            assert isinstance(ds.attrs[ds_key][var][metric],
+                                              np.ndarray)
+                            assert isinstance(
+                                ds_default_stats[ds_key_oggm][var][metric],
+                                np.ndarray)
+                    else:
+                        assert metric in ds.attrs[ds_key][var].keys()
+                        assert metric in ds_default_stats[ds_key_oggm][var].keys()
+                        assert isinstance(ds.attrs[ds_key][var][metric],
+                                          float)
+                        assert isinstance(ds_default_stats[ds_key_oggm][var][metric],
                                           float)
 
             # test the past evolution statistics

--- a/combine1d/tests/test_sandbox.py
+++ b/combine1d/tests/test_sandbox.py
@@ -6,9 +6,9 @@ import os
 import pickle
 
 from combine1d.core.inversion import get_default_inversion_settings
+from combine1d.core.massbalance import StackedMassBalance
 from combine1d.sandbox.create_glaciers_with_measurements import create_idealized_experiments
 from combine1d.sandbox.define_idealized_experiment import idealized_experiment
-from combine1d.sandbox.create_glaciers_with_measurements import StackedMassBalance
 
 from oggm import cfg
 

--- a/combine1d/tests/test_sandbox.py
+++ b/combine1d/tests/test_sandbox.py
@@ -14,6 +14,8 @@ from oggm import cfg
 
 do_plot = False
 
+pytestmark = pytest.mark.filterwarnings("ignore:<class 'combine1d.core.torch_interp1d.Interp1d'> "
+                                        "should not be instantiated.:DeprecationWarning")
 
 class TestSandbox:
     def test_create_idealized_experiments(self, test_dir):

--- a/combine1d/tests/test_special_gradient_functions.py
+++ b/combine1d/tests/test_special_gradient_functions.py
@@ -36,6 +36,10 @@ def test_Interp1d_gradient_calculation():
     input_parameters = (x, y, x_new)
     assert gradcheck(Interp1d(), input_parameters)
 
+    # check if it also works at the given points
+    input_parameters = (x, y, x)
+    assert gradcheck(Interp1d(), input_parameters)
+
 
 def test_SolveBandedPyTorch(data_dir):
     # just creating some dummy data for testing


### PR DESCRIPTION
In this PR I added a wrapper for all oggm-compatible MassBalanceModels. With this all MBModels can be made differentiable, and therefore be used during the inversion.

However, with the wrapper, it is not possible to use mass-balance parameters as control variables. For this, I will reimplement some MassBalanceModels in the future...

- [x] tests added and passed